### PR TITLE
Load files with lambda expressions from disk

### DIFF
--- a/repl/src/main/scala/nl/soqua/lcpi/repl/Main.scala
+++ b/repl/src/main/scala/nl/soqua/lcpi/repl/Main.scala
@@ -1,9 +1,14 @@
 package nl.soqua.lcpi.repl
 
+import java.io.File
+
 import nl.soqua.lcpi.interpreter.Context
-import nl.soqua.lcpi.repl.lib.CombinatorLibrary
+import nl.soqua.lcpi.repl.lib.{CombinatorLibrary, DiskIO}
 import nl.soqua.lcpi.repl.monad.{ReplCompiler, ReplState}
 import nl.soqua.lcpi.repl.parser.StdInParser
+
+import scala.io.Source
+import scala.util.Try
 
 object Main extends App {
   var ctx = CombinatorLibrary loadIn Context()
@@ -21,10 +26,16 @@ object Main extends App {
   var state = ReplState.empty
   var effect: Any = _
 
+  val compiler = ReplCompiler.compiler(new DiskIO() {
+    override def load(path: String): Try[Stream[String]] = Try {
+      Source.fromFile(new File(path)).getLines().toStream
+    }
+  })
+
   for (ln <- io.Source.stdin.getLines) {
     StdInParser(ln) match {
       case Left(e) => println(e)
-      case Right(cmd) => cmd.foldMap(ReplCompiler.pureCompiler).run(state).value match {
+      case Right(cmd) => cmd.foldMap(compiler).run(state).value match {
         case (s: ReplState, _) if s.terminated =>
           System.exit(0)
         case (s: ReplState, effect: String) =>

--- a/repl/src/main/scala/nl/soqua/lcpi/repl/Messages.scala
+++ b/repl/src/main/scala/nl/soqua/lcpi/repl/Messages.scala
@@ -1,10 +1,19 @@
 package nl.soqua.lcpi.repl
 
+import java.io.File
+
+import scala.util.Try
+
 object Messages {
+
+  private def relativePath: String = Try {
+    new File(".").getAbsolutePath
+  }.getOrElse("unknown")
+
   val help: String =
-    """
+    s"""
       |Notation:
-      |* λ is either a λ or a \. So both \x.x and λx.x are allowed.
+      |* λ is either a λ or a \\. So both \\x.x and λx.x are allowed.
       |* You can assign variables; `I := λx.x` stores the identity function to the variable `I`.
       |  These have to be capitalized.
       |
@@ -12,6 +21,7 @@ object Messages {
       |* `help` => show this message. Alias: `exit`.
       |* `quit` => quit the REPL.
       |* `show` => show the current REPL context.
+      |* `load <name>` => load a file based on the relative path ($relativePath). Lines starting with `#` are ignored
       |* `trace` => toggle trace mode
       |* `reset` => reset the current REPL context.
     """.stripMargin

--- a/repl/src/main/scala/nl/soqua/lcpi/repl/lib/DiskIO.scala
+++ b/repl/src/main/scala/nl/soqua/lcpi/repl/lib/DiskIO.scala
@@ -1,0 +1,7 @@
+package nl.soqua.lcpi.repl.lib
+
+import scala.util.Try
+
+trait DiskIO {
+  def load(path: String): Try[Stream[String]]
+}

--- a/repl/src/main/scala/nl/soqua/lcpi/repl/monad/ReplMonad.scala
+++ b/repl/src/main/scala/nl/soqua/lcpi/repl/monad/ReplMonad.scala
@@ -15,6 +15,8 @@ case object Reset extends ReplMonadA[Unit]
 
 case object TraceMode extends ReplMonadA[String]
 
+case class LoadFile(path: String) extends ReplMonadA[String]
+
 case class Command(expression: ReplExpression) extends ReplMonadA[String]
 
 object ReplMonad {
@@ -29,6 +31,8 @@ object ReplMonad {
   def reset(): Repl[Unit] = Free.liftF[ReplMonadA, Unit](Reset)
 
   def trace(): Repl[String] = Free.liftF[ReplMonadA, String](TraceMode)
+
+  def load(path: String): Repl[String] = Free.liftF[ReplMonadA, String](LoadFile(path))
 
   def expression(e: ReplExpression): Free[ReplMonadA, String] = Free.liftF[ReplMonadA, String](Command(e))
 

--- a/repl/src/main/scala/nl/soqua/lcpi/repl/parser/StdInParser.scala
+++ b/repl/src/main/scala/nl/soqua/lcpi/repl/parser/StdInParser.scala
@@ -15,7 +15,7 @@ trait StdInParserRules extends RegexParsers with PackratParsers {
   override val whiteSpace: Regex = "[\r\n]+".r
 
   lazy val line: P[Repl[_]] = {
-    help | quit | show | reset | trace | command
+    help | quit | show | reset | trace | load | command
   }
 
   lazy val help: P[Repl[_]] = {
@@ -36,6 +36,10 @@ trait StdInParserRules extends RegexParsers with PackratParsers {
 
   lazy val trace: P[Repl[_]] = {
     "trace".r ^^ (_ => ReplMonad.trace())
+  }
+
+  lazy val load: P[Repl[_]] = {
+    "load".r ~> "\\s+".r ~> "[a-zA-Z0-9_.-]+".r ^^ (p => ReplMonad.load(p))
   }
 
   lazy val command: P[Repl[_]] = {

--- a/repl/src/test/scala/nl/soqua/lcpi/repl/parser/StdInParserSpec.scala
+++ b/repl/src/test/scala/nl/soqua/lcpi/repl/parser/StdInParserSpec.scala
@@ -13,7 +13,8 @@ class StdInParserSpec extends StdInParserTester with WordSpecLike with Matchers 
         "quit" -> ReplMonad.quit(),
         "show" -> ReplMonad.show(),
         "reset" -> ReplMonad.reset(),
-        "trace" -> ReplMonad.trace()
+        "trace" -> ReplMonad.trace(),
+        "load appel.csv" -> ReplMonad.load("appel.csv")
       ) foreach {
         case (input, output) => input >> output
       }


### PR DESCRIPTION
Add the ability to load files from disk. 

* Lines starting with `#` are deemed to be comments
* Invalid lines (because of any reason) are silently discarded
* Existing variables can be overwritten (since loading form file is preferred over standard terms)