### PR TITLE
Context must be mutable during `reload`

### DIFF
--- a/repl/src/main/scala/nl/soqua/lcpi/repl/monad/ReplState.scala
+++ b/repl/src/main/scala/nl/soqua/lcpi/repl/monad/ReplState.scala
@@ -10,7 +10,7 @@ private[monad] case object Enabled extends TraceModePosition
 private[monad] case object Disabled extends TraceModePosition
 
 object ReplState {
-  val empty: ReplState = ReplState(CombinatorLibrary.loadIn(Context()), traceMode = Disabled, terminated = false, List.empty)
+  val empty: ReplState = ReplState(CombinatorLibrary.loadIn(Context()), traceMode = Disabled, terminated = false, contextIsMutable = false, List.empty)
 }
 
-case class ReplState(context: Context, traceMode: TraceModePosition, terminated: Boolean, reloadableFiles: List[String])
+case class ReplState(context: Context, traceMode: TraceModePosition, terminated: Boolean, contextIsMutable: Boolean, reloadableFiles: List[String])


### PR DESCRIPTION
During reloads, context must be mutable because an existing definition might be changed.
In that case, the existing definition should be overwritten.