### PR TITLE
Render de bruijn index

### DIFF
--- a/interpreter/src/main/scala/nl/soqua/lcpi/interpreter/transformation/DeBruijn.scala
+++ b/interpreter/src/main/scala/nl/soqua/lcpi/interpreter/transformation/DeBruijn.scala
@@ -5,7 +5,7 @@ import nl.soqua.lcpi.ast.lambda.{Application, Expression, LambdaAbstraction, Var
 import scala.language.implicitConversions
 import scala.util.Try
 
-object DeBruijnIndex {
+object DeBruijn {
 
   import AlphaReduction.α
   import Names.unused

--- a/interpreter/src/test/scala/nl/soqua/lcpi/interpreter/InterpreterTester.scala
+++ b/interpreter/src/test/scala/nl/soqua/lcpi/interpreter/InterpreterTester.scala
@@ -3,7 +3,7 @@ package nl.soqua.lcpi.interpreter
 import nl.soqua.lcpi.ast.interpreter.ReplExpression
 import nl.soqua.lcpi.ast.interpreter.ReplExpression._
 import nl.soqua.lcpi.ast.lambda.{Expression, Variable}
-import nl.soqua.lcpi.interpreter.transformation.{DeBruijnIndex, Stringify}
+import nl.soqua.lcpi.interpreter.transformation.{DeBruijn, Stringify}
 import nl.soqua.lcpi.parser.repl.ReplParser
 import org.scalatest.Matchers
 
@@ -63,7 +63,7 @@ trait InterpreterTester {
              |expected: ${Stringify(expectedExpression)}
              |---
           """.stripMargin) {
-          DeBruijnIndex.index(actualExpression.expression) shouldBe DeBruijnIndex.index(expectedExpression)
+          DeBruijn.index(actualExpression.expression) shouldBe DeBruijn.index(expectedExpression)
         }
       })
     }

--- a/interpreter/src/test/scala/nl/soqua/lcpi/interpreter/transformation/AlphaReductionSpec.scala
+++ b/interpreter/src/test/scala/nl/soqua/lcpi/interpreter/transformation/AlphaReductionSpec.scala
@@ -33,7 +33,7 @@ class AlphaReductionSpec extends WordSpec with Matchers {
            |expected: ${Stringify(expected)}
            |---
           """.stripMargin) {
-        DeBruijnIndex.index(alpha) shouldBe DeBruijnIndex.index(expected)
+        DeBruijn.index(alpha) shouldBe DeBruijn.index(expected)
       }
     }
   }

--- a/interpreter/src/test/scala/nl/soqua/lcpi/interpreter/transformation/DeBruijnSpec.scala
+++ b/interpreter/src/test/scala/nl/soqua/lcpi/interpreter/transformation/DeBruijnSpec.scala
@@ -4,9 +4,9 @@ import nl.soqua.lcpi.ast.lambda.Expression.A
 import nl.soqua.lcpi.ast.lambda.{Expression, LambdaAbstraction, Variable}
 import org.scalatest.{Matchers, WordSpec}
 
-class DeBruijnIndexSpec extends WordSpec with Matchers {
+class DeBruijnSpec extends WordSpec with Matchers {
 
-  import DeBruijnIndex._
+  import DeBruijn._
 
   val _a = Expression.V("a")
   val b = Expression.V("b")

--- a/interpreter/src/test/scala/nl/soqua/lcpi/interpreter/transformation/IsomorphismSpec.scala
+++ b/interpreter/src/test/scala/nl/soqua/lcpi/interpreter/transformation/IsomorphismSpec.scala
@@ -9,7 +9,7 @@ import scala.language.postfixOps
 
 class IsomorphismSpec extends WordSpec with Matchers {
 
-  import DeBruijnIndex._
+  import DeBruijn._
 
   private implicit class Parse(val expr: String) extends Matchers {
     def is(o: Any): Assertion = o match {

--- a/repl/src/main/scala/nl/soqua/lcpi/repl/monad/ReplCompilerDefinition.scala
+++ b/repl/src/main/scala/nl/soqua/lcpi/repl/monad/ReplCompilerDefinition.scala
@@ -27,6 +27,7 @@ trait ReplCompilerDefinition {
       case Command(e) => command(e)
       case LoadFile(file) => load(file)
       case Reload => reload()
+      case DeBruijnIndex(e) => deBruijnIndex(e)
     }
   }
 
@@ -47,4 +48,6 @@ trait ReplCompilerDefinition {
   protected def reload(): PureReplState[String]
 
   protected def command(expression: ReplExpression): PureReplState[String]
+
+  protected def deBruijnIndex(expression: ReplExpression): PureReplState[String]
 }

--- a/repl/src/main/scala/nl/soqua/lcpi/repl/monad/ReplMonad.scala
+++ b/repl/src/main/scala/nl/soqua/lcpi/repl/monad/ReplMonad.scala
@@ -23,6 +23,9 @@ case object Reload extends ReplMonadA[String]
 
 case class Command(expression: ReplExpression) extends ReplMonadA[String]
 
+case class DeBruijnIndex(expression: ReplExpression) extends ReplMonadA[String]
+
+
 object ReplMonad {
   type Repl[A] = Free[ReplMonadA, A]
 
@@ -43,5 +46,7 @@ object ReplMonad {
   def reload(): Repl[String] = Free.liftF[ReplMonadA, String](Reload)
 
   def expression(e: ReplExpression): Free[ReplMonadA, String] = Free.liftF[ReplMonadA, String](Command(e))
+
+  def deBruijnIndex(e: ReplExpression): Free[ReplMonadA, String] = Free.liftF[ReplMonadA, String](DeBruijnIndex(e))
 
 }

--- a/repl/src/main/scala/nl/soqua/lcpi/repl/parser/StdInParser.scala
+++ b/repl/src/main/scala/nl/soqua/lcpi/repl/parser/StdInParser.scala
@@ -15,7 +15,7 @@ trait StdInParserRules extends RegexParsers with PackratParsers {
   override val whiteSpace: Regex = "[\r\n]+".r
 
   lazy val line: P[Repl[_]] = {
-    help | quit | show | reset | trace | load | reload | command
+    help | quit | show | reset | trace | load | reload | deBruijnIndex | command
   }
 
   lazy val help: P[Repl[_]] = {
@@ -44,6 +44,13 @@ trait StdInParserRules extends RegexParsers with PackratParsers {
 
   lazy val reload: P[Repl[_]] = {
     "reload".r ^^ (_ => ReplMonad.reload())
+  }
+
+  lazy val deBruijnIndex: P[Repl[_]] = {
+    "dbi".r ~> ".*".r >> (v => ReplParser(v) match {
+      case Left(e) => failure(e.message)
+      case Right(e) => success(ReplMonad.deBruijnIndex(e))
+    })
   }
 
   lazy val command: P[Repl[_]] = {

--- a/repl/src/test/scala/nl/soqua/lcpi/repl/monad/ReplCompilerSpec.scala
+++ b/repl/src/test/scala/nl/soqua/lcpi/repl/monad/ReplCompilerSpec.scala
@@ -2,6 +2,7 @@ package nl.soqua.lcpi.repl.monad
 
 import nl.soqua.lcpi.ast.interpreter.Assignment
 import nl.soqua.lcpi.ast.lambda.{Application, Variable}
+import nl.soqua.lcpi.ast.lambda.Expression.{λ, V}
 import nl.soqua.lcpi.interpreter.Context
 import nl.soqua.lcpi.repl.Messages
 import nl.soqua.lcpi.repl.lib.{CombinatorLibrary, DiskIO}
@@ -96,6 +97,15 @@ class ReplCompilerSpec extends ReplMonadTester with WordSpecLike with Matchers {
     }
     "fail to reload when no file is loaded yet" in {
       ReplMonad.reload() >> "Failed to reload: no file has been loaded yet"
+    }
+    "render an expression in De Bruijn Index notation" in {
+      val x = V("x")
+      ReplMonad.deBruijnIndex(λ(x, x)) >> "(λ.1)"
+    }
+    "not be able to render a failure as de bruijn index" in {
+      val x = V("x")
+      val e = Assignment(V("I"), λ(x, x))
+      ReplMonad.deBruijnIndex(e) >> "The variable 'I' has already been assigned in the context"
     }
   }
   "A repl compiler with failing disk io" should {

--- a/repl/src/test/scala/nl/soqua/lcpi/repl/parser/StdInParserSpec.scala
+++ b/repl/src/test/scala/nl/soqua/lcpi/repl/parser/StdInParserSpec.scala
@@ -28,5 +28,13 @@ class StdInParserSpec extends StdInParserTester with WordSpecLike with Matchers 
         "# foo" >> ReplMonad.help()
       }
     }
+    "parse a De Bruijn Index command" in {
+      "dbi λx.x" >> ReplMonad.deBruijnIndex(LambdaAbstraction(Variable("x"), Variable("x")))
+    }
+    "don't parse an invalid De Bruijn Index command" in {
+      assertThrows[TestFailedException] {
+        "dbi # foo" >> ReplMonad.help()
+      }
+    }
   }
 }


### PR DESCRIPTION
Add a `dbi <expr>` command to render an expression in De Bruijn Index notation. 