### PR TITLE
Add Jline ('readline') to the REPL for convenience

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This provides a parser and interpreter and REPL for the untyped lambda calculus.
 The REPL has tracing capabilities to show all intermediate reduction steps.
 Among others, the following features are supported:
 
-* Lambda is either a `λ` or a `\ `, so `\x.x` and `λx.x` are identical.
+* Lambda is either a `λ` or a `\\ `, so `\\x.x` and `λx.x` are identical.
 * There is a shorthand available for nesting, so `λx y z.x y z` is equal to `λx.λy.λz.x y z`.
 * The parser is fully left-associative, so `x y z` is `(x y) z`.
 * The REPL can toggle between a normal and a *tracing* mode, showing all intermediate reduction steps.

--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,8 @@ lazy val repl = (project in file("repl")).
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-parser-combinators" % sParSecVersion,
       "org.typelevel" %% "cats" % catsVersion,
-      "org.typelevel" %% "cats-free" % catsVersion
+      "org.typelevel" %% "cats-free" % catsVersion,
+      "org.jline" % "jline" % "3.1.2"
     ),
     mainClass in assembly := Some("nl.soqua.lcpi.repl.Main")
   ).dependsOn(ast, parser, interpreter % "test->test;compile->compile")

--- a/repl/src/main/scala/nl/soqua/lcpi/repl/Messages.scala
+++ b/repl/src/main/scala/nl/soqua/lcpi/repl/Messages.scala
@@ -13,7 +13,7 @@ object Messages {
   val help: String =
     s"""
       |Notation:
-      |* λ is either a λ or a \\. So both \\x.x and λx.x are allowed.
+      |* λ is either a λ or a \\\\. So both \\\\x.x and λx.x are allowed.
       |* You can assign variables; `I := λx.x` stores the identity function to the variable `I`.
       |  These have to be capitalized.
       |


### PR DESCRIPTION
This provides line-editing, history and Emacs bindings (or Vi).

The only downside is that the `\` lambda alternative now is `\\` because it is also a shell-escape char. 