### PR TITLE
Add a toggle for an ascii mode

### DIFF
--- a/interpreter/src/main/scala/nl/soqua/lcpi/interpreter/Context.scala
+++ b/interpreter/src/main/scala/nl/soqua/lcpi/interpreter/Context.scala
@@ -12,9 +12,6 @@ trait Context {
   def foldLeft[T](seed: T)(op: (T, Variable, Expression) => T): T =
     expressions.foldLeft(seed)((acc, t) => op(acc, t._1, t._2))
 
-  def foreach(fn: (Variable, Expression) => Unit): Unit =
-    expressions.foreach(t => fn(t._1, t._2))
-
   def map[B](fn: (Variable, Expression) => B): List[B] =
     expressions.map(t => fn(t._1, t._2))
 }

--- a/interpreter/src/main/scala/nl/soqua/lcpi/interpreter/InterpreterResult.scala
+++ b/interpreter/src/main/scala/nl/soqua/lcpi/interpreter/InterpreterResult.scala
@@ -11,8 +11,13 @@ object InterpreterResult {
 sealed trait InterpreterResult {
   val expression: Expression
   val context: Context
+  def map(f: Expression => Expression): InterpreterResult
 }
 
-case class SingleExpressionInterpreterResult(context: Context, expression: Expression) extends InterpreterResult
+case class SingleExpressionInterpreterResult(context: Context, expression: Expression) extends InterpreterResult {
+  override def map(f: (Expression) => Expression): InterpreterResult = copy(expression = f(expression))
+}
 
-case class TraceInterpreterResult(context: Context, expression: Expression, trace: List[(String, Expression)]) extends InterpreterResult
+case class TraceInterpreterResult(context: Context, expression: Expression, trace: List[(String, Expression)]) extends InterpreterResult {
+  override def map(f: (Expression) => Expression): InterpreterResult = copy(expression = f(expression))
+}

--- a/interpreter/src/main/scala/nl/soqua/lcpi/interpreter/show/Show.scala
+++ b/interpreter/src/main/scala/nl/soqua/lcpi/interpreter/show/Show.scala
@@ -9,8 +9,6 @@ sealed trait Show
 object Show {
   type ShowS = StringBuilder => StringBuilder
 
-  implicit def sb2s(sb: StringBuilder): String = sb.toString()
-
   implicit def showS2string(f: ShowS): String = f(StringBuilder.newBuilder).toString().reverse
 
   implicit def str2s(s: String): ShowS = string(s)

--- a/repl/src/main/scala/nl/soqua/lcpi/repl/Messages.scala
+++ b/repl/src/main/scala/nl/soqua/lcpi/repl/Messages.scala
@@ -24,10 +24,14 @@ object Messages {
       |* `load <name>` => load a file based on the relative path ($relativePath). Lines starting with `#` are ignored.
       |* `reload` => reload all files, overwriting any existing variables in the context if they already exist.
       |* `trace` => toggle trace mode.
+      |* `ascii` => toggle ascii mode in case your terminal can't render the lambda character λ.
       |* `reset` => reset the current REPL context.
       |* `<λ-expression>` => evaluate a λ-expression.
       |* `dbi <λ-expression>` => evaluate a λ-expression and render the result in De Bruijn Index notation.
     """.stripMargin
   val traceModeEnabled: String = "Trace mode is now on."
   val traceModeDisabled: String = "Trace mode is now off."
+
+  val asciiModeEnabled: String = "Ascii mode is now on. Lambdas will be rendered as `\\\\`"
+  val asciiModeDisabled: String = "Ascii mode is now off. Lambdas will be rendered as `λ`"
 }

--- a/repl/src/main/scala/nl/soqua/lcpi/repl/monad/ReplCompilerDefinition.scala
+++ b/repl/src/main/scala/nl/soqua/lcpi/repl/monad/ReplCompilerDefinition.scala
@@ -24,6 +24,7 @@ trait ReplCompilerDefinition {
       case Reset => reset()
       case ShowContext => show()
       case TraceMode => trace()
+      case AsciiMode => ascii()
       case EvaluateReplExpression(e) => replExpression(e)
       case LoadFile(file) => load(file)
       case Reload => reload()
@@ -42,6 +43,8 @@ trait ReplCompilerDefinition {
   protected def reset(): PureReplState[Unit]
 
   protected def trace(): PureReplState[String]
+
+  protected def ascii(): PureReplState[String]
 
   protected def load(file: String): PureReplState[String]
 

--- a/repl/src/main/scala/nl/soqua/lcpi/repl/monad/ReplMonad.scala
+++ b/repl/src/main/scala/nl/soqua/lcpi/repl/monad/ReplMonad.scala
@@ -17,6 +17,8 @@ case object Reset extends ReplMonadA[Unit]
 
 case object TraceMode extends ReplMonadA[String]
 
+case object AsciiMode extends ReplMonadA[String]
+
 case class LoadFile(path: String) extends ReplMonadA[String]
 
 case object Reload extends ReplMonadA[String]
@@ -40,6 +42,8 @@ object ReplMonad {
   def reset(): Repl[Unit] = Free.liftF[ReplMonadA, Unit](Reset)
 
   def trace(): Repl[String] = Free.liftF[ReplMonadA, String](TraceMode)
+
+  def ascii(): Repl[String] = Free.liftF[ReplMonadA, String](AsciiMode)
 
   def load(path: String): Repl[String] = Free.liftF[ReplMonadA, String](LoadFile(path))
 

--- a/repl/src/main/scala/nl/soqua/lcpi/repl/monad/ReplState.scala
+++ b/repl/src/main/scala/nl/soqua/lcpi/repl/monad/ReplState.scala
@@ -5,12 +5,16 @@ import nl.soqua.lcpi.repl.lib.CombinatorLibrary
 
 private[monad] sealed trait TraceModePosition
 
-private[monad] case object Enabled extends TraceModePosition
+private[monad] sealed trait AsciiModeToggle
 
-private[monad] case object Disabled extends TraceModePosition
+private[monad] case object Enabled extends TraceModePosition with AsciiModeToggle
+
+private[monad] case object Disabled extends TraceModePosition with AsciiModeToggle
 
 object ReplState {
-  val empty: ReplState = ReplState(CombinatorLibrary.loadIn(Context()), traceMode = Disabled, terminated = false, contextIsMutable = false, List.empty)
+  val empty: ReplState = ReplState(CombinatorLibrary.loadIn(Context()), traceMode = Disabled, asciiMode = Disabled,
+    terminated = false, contextIsMutable = false, List.empty)
 }
 
-case class ReplState(context: Context, traceMode: TraceModePosition, terminated: Boolean, contextIsMutable: Boolean, reloadableFiles: List[String])
+case class ReplState(context: Context, traceMode: TraceModePosition, asciiMode: AsciiModeToggle, terminated: Boolean,
+                     contextIsMutable: Boolean, reloadableFiles: List[String])

--- a/repl/src/main/scala/nl/soqua/lcpi/repl/parser/StdInParser.scala
+++ b/repl/src/main/scala/nl/soqua/lcpi/repl/parser/StdInParser.scala
@@ -15,7 +15,7 @@ trait StdInParserRules extends RegexParsers with PackratParsers {
   override val whiteSpace: Regex = "[\r\n]+".r
 
   lazy val line: P[Repl[_]] = {
-    help | quit | show | reset | trace | load | reload | deBruijnIndex | command
+    help | quit | show | reset | trace | ascii | load | reload | deBruijnIndex | command
   }
 
   lazy val help: P[Repl[_]] = {
@@ -36,6 +36,10 @@ trait StdInParserRules extends RegexParsers with PackratParsers {
 
   lazy val trace: P[Repl[_]] = {
     "trace".r ^^ (_ => ReplMonad.trace())
+  }
+
+  lazy val ascii: P[Repl[_]] = {
+    "ascii".r ^^ (_ => ReplMonad.ascii())
   }
 
   lazy val load: P[Repl[_]] = {

--- a/repl/src/test/scala/nl/soqua/lcpi/repl/monad/ReplCompilerSpec.scala
+++ b/repl/src/test/scala/nl/soqua/lcpi/repl/monad/ReplCompilerSpec.scala
@@ -40,6 +40,31 @@ class ReplCompilerSpec extends ReplMonadTester with WordSpecLike with Matchers {
       ReplMonad.trace() >> emptyState.copy(traceMode = Disabled)
       ReplMonad.trace() >> Messages.traceModeDisabled
     }
+    "toggle ascii mode on" in {
+      ReplMonad.ascii() >> emptyState.copy(asciiMode = Enabled)
+      ReplMonad.ascii() >> Messages.asciiModeEnabled
+    }
+    "toggle ascii mode off" in {
+      implicit val state: ReplState = emptyState.copy(asciiMode = Enabled)
+      ReplMonad.ascii() >> emptyState.copy(asciiMode = Disabled)
+      ReplMonad.ascii() >> Messages.asciiModeDisabled
+    }
+    "render lambda's as `\\\\` when ascii mode is enabled" in {
+      implicit val state: ReplState = emptyState.copy(asciiMode = Enabled)
+      val x = V("x")
+      ReplMonad.deBruijnIndex(λ(x, x)) >> "\\\\.1"
+    }
+    "render lambda's as `\\\\` when ascii and trace mode is enabled" in {
+      implicit val state: ReplState = emptyState.copy(asciiMode = Enabled, traceMode = Enabled)
+      val x = V("x")
+      ReplMonad.evalExpression(λ(x, x)) >> List(
+        "S => \\\\x.x",
+        "S => \\\\x.x",
+        "α => \\\\x.x",
+        "η => \\\\x.x",
+        "\\\\x.x"
+      ).mkString(System.lineSeparator())
+    }
     "show the current environment if asked for" in {
       val c = Context()
         .assign(Variable("FOO"), Variable("y"))

--- a/repl/src/test/scala/nl/soqua/lcpi/repl/parser/StdInParserSpec.scala
+++ b/repl/src/test/scala/nl/soqua/lcpi/repl/parser/StdInParserSpec.scala
@@ -14,6 +14,7 @@ class StdInParserSpec extends StdInParserTester with WordSpecLike with Matchers 
         "show" -> ReplMonad.showContext(),
         "reset" -> ReplMonad.reset(),
         "trace" -> ReplMonad.trace(),
+        "ascii" -> ReplMonad.ascii(),
         "load appel.csv" -> ReplMonad.load("appel.csv"),
         "reload" -> ReplMonad.reload()
       ) foreach {


### PR DESCRIPTION
This is disabled by default. If enabled it will render λ characters as \\
so that they can be displayed on terminals that don't support these characters.